### PR TITLE
Change archive format for pre-built binary

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -122,8 +122,8 @@ jobs:
           gzip -k -v -9 "${package}.tar"
           lzip -v -9 "${package}.tar"
         else
-          7z a -bb -mx=9 "${package}.7z" "${package}"
-          7z a -bb -mx=9 "${package}.zip" "${package}"
+          7z a -bb -mx=9 -m0=LZMA "${package}.7z" "${package}"
+          7z a -bb -mx=9 -mm=Deflate "${package}.zip" "${package}"
         fi
         rm -rv rscrypt-*/
     - name: Upload artifact

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,8 @@ toc::[]
 === Changed
 
 * Rename value of `--max-memory` option ({pull-request-url}/199[#199])
+* Use LZMA instead of LZMA2 in 7z format for pre-built binary
+  ({pull-request-url}/200[#200])
 
 == {compare-url}/v0.5.5\...v0.5.6[0.5.6] - 2023-08-03
 


### PR DESCRIPTION
Use LZMA instead of LZMA2 in 7z format.