### PR TITLE
Reduce output format of encryption parameters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 25
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -29,27 +29,7 @@ just build
 
 == Crate features
 
-`cbor`::
-
-  Enable outputting the encryption parameters as CBOR. This is enabled by
-  default.
-
 `json`::
 
   Enable outputting the encryption parameters as JSON. This is enabled by
-  default.
-
-`msgpack`::
-
-  Enable outputting the encryption parameters as MessagePack. This is enabled
-  by default.
-
-`toml`::
-
-  Enable outputting the encryption parameters as TOML. This is enabled by
-  default.
-
-`yaml`::
-
-  Enable outputting the encryption parameters as YAML. This is enabled by
   default.

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.6.3\...HEAD[Unreleased]
+
+=== Changed
+
+* Reduce the output format of the encryption parameters to JSON only
+  ({pull-request-url}/315[#315])
+
 == {compare-url}/v0.6.2\...v0.6.3[0.6.3] - 2023-10-03
 
 === Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,12 +134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,33 +147,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "ciborium"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
-dependencies = [
- "ciborium-io",
- "half",
-]
 
 [[package]]
 name = "cipher"
@@ -395,12 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,18 +422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,16 +447,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "inout"
@@ -661,12 +600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "paste"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,28 +745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
-name = "rmp"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,7 +810,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "byte-unit",
- "ciborium",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -908,15 +818,12 @@ dependencies = [
  "humantime",
  "once_cell",
  "predicates",
- "rmp-serde",
  "scryptenc",
  "serde",
  "serde_json",
- "serde_yaml",
  "sysexits",
  "sysinfo",
  "thiserror",
- "toml",
 ]
 
 [[package]]
@@ -948,28 +855,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1070,40 +955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,12 +971,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "utf8-width"
@@ -1313,15 +1158,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "winnow"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.75"
 byte-unit = "4.0.19"
-ciborium = { version = "0.2.1", optional = true }
 clap = { version = "4.4.7", features = ["derive", "wrap_help"] }
 clap_complete = "4.4.4"
 clap_complete_nushell = "4.4.2"
@@ -45,27 +44,20 @@ dialoguer = { version = "0.11.0", default-features = false, features = ["passwor
 fraction = { version = "0.14.0", default-features = false }
 humantime = "2.1.0"
 once_cell = "1.18.0"
-rmp-serde = { version = "1.1.2", optional = true }
 scryptenc = "0.8.3"
 serde = { version = "1.0.190", features = ["derive"], optional = true }
 serde_json = { version = "1.0.108", optional = true }
-serde_yaml = { version = "0.9.27", optional = true }
 sysexits = "0.7.4"
 sysinfo = "0.29.10"
 thiserror = "1.0.50"
-toml = { version = "0.8.6", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = "3.0.4"
 
 [features]
-default = ["cbor", "json", "msgpack", "toml", "yaml"]
-cbor = ["dep:ciborium", "dep:serde"]
+default = ["json"]
 json = ["dep:serde", "dep:serde_json"]
-msgpack = ["dep:rmp-serde", "dep:serde"]
-toml = ["dep:serde", "dep:toml"]
-yaml = ["dep:serde", "dep:serde_yaml"]
 
 [profile.release]
 lto = true

--- a/build.rs
+++ b/build.rs
@@ -21,16 +21,8 @@ fn generate_man_page(out_dir: impl AsRef<Path>) -> io::Result<ExitStatus> {
     command
         .args(["-b", "manpage"])
         .args(["-a", concat!("revnumber=", env!("CARGO_PKG_VERSION"))]);
-    #[cfg(feature = "cbor")]
-    command.args(["-a", "cbor"]);
     #[cfg(feature = "json")]
     command.args(["-a", "json"]);
-    #[cfg(feature = "msgpack")]
-    command.args(["-a", "msgpack"]);
-    #[cfg(feature = "toml")]
-    command.args(["-a", "toml"]);
-    #[cfg(feature = "yaml")]
-    command.args(["-a", "yaml"]);
     command
         .args(["-D".as_ref(), out_dir.as_ref()])
         .args([

--- a/doc/man/man1/rscrypt-info.1.adoc
+++ b/doc/man/man1/rscrypt-info.1.adoc
@@ -4,7 +4,7 @@
 
 = rscrypt-info(1)
 // Specify in UTC.
-:docdate: 2023-07-17
+:docdate: 2023-11-04
 :doctype: manpage
 ifdef::revnumber[:mansource: rscrypt {revnumber}]
 :manmanual: General Commands Manual
@@ -30,42 +30,10 @@ _FILE_::
 
 == OPTIONS
 
-ifdef::cbor,json,msgpack,toml,yaml,env-github,site-gen-antora[]
-*-f*, *--format* _FORMAT_::
-
-  Output format.
-
-  The possible values are:{blank}:::
-
-ifdef::cbor,env-github,site-gen-antora[]
-    *cbor*::::
-
-      Concise Binary Object Representation.
-endif::cbor,env-github,site-gen-antora[]
-
 ifdef::json,env-github,site-gen-antora[]
-    *json*::::
+*-j*, *--json*::
 
-      JavaScript Object Notation.
-endif::json,env-github,site-gen-antora[]
-
-ifdef::msgpack,env-github,site-gen-antora[]
-    *msgpack*::::
-
-      MessagePack.
-endif::msgpack,env-github,site-gen-antora[]
-
-ifdef::toml,env-github,site-gen-antora[]
-    *toml*::::
-
-      Tom's Obvious Minimal Language.
-endif::toml,env-github,site-gen-antora[]
-
-ifdef::yaml,env-github,site-gen-antora[]
-    *yaml*::::
-
-      YAML.
-endif::yaml,env-github,site-gen-antora[]
+  Output the encryption parameters as JSON.
 endif::[]
 
 *-h*, *--help*::

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,33 +161,19 @@ pub fn run() -> anyhow::Result<()> {
                 let input = input::read(&arg.input)?;
 
                 let params = params::get(&input, &arg.input)?;
-                #[cfg(any(
-                    feature = "cbor",
-                    feature = "json",
-                    feature = "msgpack",
-                    feature = "toml",
-                    feature = "yaml"
-                ))]
-                if let Some(format) = arg.format {
+                #[cfg(feature = "json")]
+                if arg.json {
                     let params = params::Params::new(params);
                     let output = params
-                        .to_vec(format)
+                        .to_vec()
                         .context("could not output the encryption parameters")?;
                     if let Ok(string) = std::str::from_utf8(&output) {
                         println!("{string}");
                     } else {
                         output::write_to_stdout(&output)?;
                     }
-                } else {
-                    params::displayln_without_resources(params.log_n(), params.r(), params.p());
+                    return Ok(());
                 }
-                #[cfg(not(any(
-                    feature = "cbor",
-                    feature = "json",
-                    feature = "msgpack",
-                    feature = "toml",
-                    feature = "yaml"
-                )))]
                 params::displayln_without_resources(params.log_n(), params.r(), params.p());
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -267,16 +267,10 @@ pub struct Decrypt {
 
 #[derive(Args, Debug)]
 pub struct Information {
-    /// Output format.
-    #[cfg(any(
-        feature = "cbor",
-        feature = "json",
-        feature = "msgpack",
-        feature = "toml",
-        feature = "yaml"
-    ))]
-    #[arg(short, long, value_enum, value_name("FORMAT"), ignore_case(true))]
-    pub format: Option<Format>,
+    /// Output the encryption parameters as JSON.
+    #[cfg(feature = "json")]
+    #[arg(short, long)]
+    pub json: bool,
 
     /// Input file.
     ///
@@ -424,37 +418,6 @@ impl FromStr for Time {
             Err(err) => Err(anyhow!("time is not a valid value: {err}")),
         }
     }
-}
-
-#[cfg(any(
-    feature = "cbor",
-    feature = "json",
-    feature = "msgpack",
-    feature = "toml",
-    feature = "yaml"
-))]
-#[derive(Clone, Copy, Debug, ValueEnum)]
-pub enum Format {
-    /// Concise Binary Object Representation.
-    #[cfg(feature = "cbor")]
-    Cbor,
-
-    /// JavaScript Object Notation.
-    #[cfg(feature = "json")]
-    Json,
-
-    /// MessagePack.
-    #[cfg(feature = "msgpack")]
-    #[value(name("msgpack"))]
-    MessagePack,
-
-    /// Tom's Obvious Minimal Language.
-    #[cfg(feature = "toml")]
-    Toml,
-
-    /// YAML.
-    #[cfg(feature = "yaml")]
-    Yaml,
 }
 
 #[cfg(test)]

--- a/src/params.rs
+++ b/src/params.rs
@@ -231,13 +231,7 @@ pub fn check(
 }
 
 /// The scrypt parameters used for the encrypted data.
-#[cfg(any(
-    feature = "cbor",
-    feature = "json",
-    feature = "msgpack",
-    feature = "toml",
-    feature = "yaml"
-))]
+#[cfg(feature = "json")]
 #[derive(Clone, Copy, Debug, serde::Serialize)]
 pub struct Params {
     #[serde(rename = "N")]
@@ -246,13 +240,7 @@ pub struct Params {
     p: u32,
 }
 
-#[cfg(any(
-    feature = "cbor",
-    feature = "json",
-    feature = "msgpack",
-    feature = "toml",
-    feature = "yaml"
-))]
+#[cfg(feature = "json")]
 impl Params {
     /// Creates a new `Params`.
     pub const fn new(params: scryptenc::Params) -> Self {
@@ -264,41 +252,7 @@ impl Params {
     }
 
     /// Serializes the given data structure.
-    pub fn to_vec(self, format: crate::cli::Format) -> anyhow::Result<Vec<u8>> {
-        #[cfg(any(feature = "toml", feature = "yaml"))]
-        use crate::utils::StringExt;
-
-        match format {
-            #[cfg(feature = "cbor")]
-            crate::cli::Format::Cbor => {
-                let mut buf = Vec::new();
-                ciborium::ser::into_writer(&self, &mut buf)
-                    .context("could not serialize as CBOR")?;
-                Ok(buf)
-            }
-            #[cfg(feature = "json")]
-            crate::cli::Format::Json => {
-                serde_json::to_vec(&self).context("could not serialize as JSON")
-            }
-            #[cfg(feature = "msgpack")]
-            crate::cli::Format::MessagePack => {
-                rmp_serde::to_vec_named(&self).context("could not serialize as MessagePack")
-            }
-            #[cfg(feature = "toml")]
-            crate::cli::Format::Toml => {
-                let mut toml = toml::to_string(&self).context("could not serialize as TOML")?;
-                toml.remove_newline();
-                let toml = toml.into_bytes();
-                Ok(toml)
-            }
-            #[cfg(feature = "yaml")]
-            crate::cli::Format::Yaml => {
-                let mut yaml =
-                    serde_yaml::to_string(&self).context("could not serialize as YAML")?;
-                yaml.remove_newline();
-                let yaml = yaml.into_bytes();
-                Ok(yaml)
-            }
-        }
+    pub fn to_vec(self) -> anyhow::Result<Vec<u8>> {
+        serde_json::to_vec(&self).context("could not serialize as JSON")
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -635,96 +635,14 @@ fn basic_information() {
         ));
 }
 
-#[cfg(not(any(
-    feature = "cbor",
-    feature = "json",
-    feature = "msgpack",
-    feature = "toml",
-    feature = "yaml"
-)))]
-#[test]
-fn info_command_without_default_feature() {
-    command()
-        .arg("info")
-        .arg("-f")
-        .arg("cbor")
-        .arg("data/data.txt.scrypt")
-        .assert()
-        .failure()
-        .code(2);
-}
-
-#[cfg(feature = "cbor")]
-#[test]
-fn information_as_cbor() {
-    command()
-        .arg("info")
-        .arg("-f")
-        .arg("cbor")
-        .arg("data/data.txt.scrypt")
-        .assert()
-        .success()
-        .stdout(predicate::eq(
-            [
-                0xa3, 0x61, 0x4e, 0x19, 0x04, 0x00, 0x61, 0x72, 0x08, 0x61, 0x70, 0x01,
-            ]
-            .as_slice(),
-        ));
-}
-
 #[cfg(feature = "json")]
 #[test]
 fn information_as_json() {
     command()
         .arg("info")
-        .arg("-f")
-        .arg("json")
+        .arg("-j")
         .arg("data/data.txt.scrypt")
         .assert()
         .success()
         .stdout(predicate::eq(concat!(r#"{"N":1024,"r":8,"p":1}"#, '\n')));
-}
-
-#[cfg(feature = "msgpack")]
-#[test]
-fn information_as_msgpack() {
-    command()
-        .arg("info")
-        .arg("-f")
-        .arg("msgpack")
-        .arg("data/data.txt.scrypt")
-        .assert()
-        .success()
-        .stdout(predicate::eq(
-            [
-                0x83, 0xa1, 0x4e, 0xcd, 0x04, 0x00, 0xa1, 0x72, 0x08, 0xa1, 0x70, 0x01,
-            ]
-            .as_slice(),
-        ));
-}
-
-#[cfg(feature = "toml")]
-#[test]
-fn information_as_toml() {
-    command()
-        .arg("info")
-        .arg("-f")
-        .arg("toml")
-        .arg("data/data.txt.scrypt")
-        .assert()
-        .success()
-        .stdout(predicate::eq("N = 1024\nr = 8\np = 1\n"));
-}
-
-#[cfg(feature = "yaml")]
-#[test]
-fn information_as_yaml() {
-    command()
-        .arg("info")
-        .arg("-f")
-        .arg("yaml")
-        .arg("data/data.txt.scrypt")
-        .assert()
-        .success()
-        .stdout(predicate::eq("N: 1024\nr: 8\np: 1\n"));
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

Reduce the output format of the encryption parameters to JSON only. This is because JSON can be converted to other formats easily.

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [x] I have read the [Contribution Guide].
- [x] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/rscrypt/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/rscrypt/blob/develop/CODE_OF_CONDUCT.md
